### PR TITLE
 Ensure Paranoia runs after_commit on: :destroy callbacks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,11 @@ rvm:
 
 env:
   matrix:
-    - RAILS='~> 4.2.0'
-    - RAILS='~> 5.0.0'
     - RAILS='~> 5.1.0'
     - RAILS='~> 5.2.0'
 
 matrix:
   allow_failures:
-    - env: RAILS='~> 4.2.0'
-      rvm: jruby-9.1.6.0
-    - env: RAILS='~> 5.0.0'
-      rvm: jruby-9.1.6.0
     - env: RAILS='~> 5.1.0'
       rvm: jruby-9.1.6.0
     - env: RAILS='~> 5.2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'sqlite3', platforms: [:ruby]
+gem 'sqlite3', '~> 1.3.6', platforms: [:ruby]
 
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter'

--- a/paranoia.gemspec
+++ b/paranoia.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0'
 
-  s.add_dependency 'activerecord', '>= 4.0', '< 5.3'
+  s.add_dependency 'activerecord', '>= 5.1', '< 5.3'
 
   s.add_development_dependency "bundler", ">= 1.0.0"
   s.add_development_dependency "rake"

--- a/test/paranoia_test.rb
+++ b/test/paranoia_test.rb
@@ -46,7 +46,7 @@ def setup!
     'active_column_models' => 'deleted_at DATETIME, active BOOLEAN',
     'active_column_model_with_uniqueness_validations' => 'name VARCHAR(32), deleted_at DATETIME, active BOOLEAN',
     'paranoid_model_with_belongs_to_active_column_model_with_has_many_relationships' => 'name VARCHAR(32), deleted_at DATETIME, active BOOLEAN, active_column_model_with_has_many_relationship_id INTEGER',
-    'active_column_model_with_has_many_relationships' => 'name VARCHAR(32), deleted_at DATETIME, active BOOLEAN', 
+    'active_column_model_with_has_many_relationships' => 'name VARCHAR(32), deleted_at DATETIME, active BOOLEAN',
     'without_default_scope_models' => 'deleted_at DATETIME'
   }.each do |table_name, columns_as_sql_string|
     ActiveRecord::Base.connection.execute "CREATE TABLE #{table_name} (id INTEGER NOT NULL PRIMARY KEY, #{columns_as_sql_string})"
@@ -113,6 +113,18 @@ class ParanoiaTest < test_framework
 
     assert_equal 0, model.class.count
     assert_equal 0, model.class.unscoped.count
+  end
+
+  def test_after_commit_on_destroy_callbacks
+    model = AfterCommitDestroyModel.new
+    model.save
+
+    model.reset_after_commit_callback_called
+    refute model.after_commit_callback_called
+
+    model.destroy
+
+    assert model.after_commit_callback_called
   end
 
   # Anti-regression test for #81, which would've introduced a bug to break this test.
@@ -189,11 +201,11 @@ class ParanoiaTest < test_framework
     p2 = ParanoidModel.create(:parent_model => parent2)
     p1.destroy
     p2.destroy
-    
+
     assert_equal 0, parent1.paranoid_models.count
     assert_equal 1, parent1.paranoid_models.only_deleted.count
 
-    assert_equal 2, ParanoidModel.only_deleted.joins(:parent_model).count    
+    assert_equal 2, ParanoidModel.only_deleted.joins(:parent_model).count
     assert_equal 1, parent1.paranoid_models.deleted.count
     assert_equal 0, parent1.paranoid_models.without_deleted.count
     p3 = ParanoidModel.create(:parent_model => parent1)
@@ -206,7 +218,7 @@ class ParanoiaTest < test_framework
     c1 = ActiveColumnModelWithHasManyRelationship.create(name: 'Jacky')
     c2 = ActiveColumnModelWithHasManyRelationship.create(name: 'Thomas')
     p1 = ParanoidModelWithBelongsToActiveColumnModelWithHasManyRelationship.create(name: 'Hello', active_column_model_with_has_many_relationship: c1)
-    
+
     c1.destroy
     assert_equal 1, ActiveColumnModelWithHasManyRelationship.count
     assert_equal 1, ActiveColumnModelWithHasManyRelationship.only_deleted.count
@@ -1369,5 +1381,24 @@ module Namespaced
   class ParanoidBelongsTo < ActiveRecord::Base
     acts_as_paranoid
     belongs_to :paranoid_has_one
+  end
+end
+
+class AfterCommitDestroyModel < ActiveRecord::Base
+  self.table_name = 'callback_models'
+
+  attr_reader :after_commit_callback_called
+
+  acts_as_paranoid
+  after_commit :callback_triggered, on: :destroy
+
+  def reset_after_commit_callback_called
+    @after_commit_callback_called = false
+  end
+
+  private
+
+  def callback_triggered
+    @after_commit_callback_called = true
   end
 end


### PR DESCRIPTION
Rails 5.1+ adds a @_trigger_destroy_callback instance variable to
ActiveRecord's internal code, which it checks to see if it should run
those callbacks. Paranoia 2.4.1 isn't aware of that variable, which
causes after_commit on: :destroy callbacks to not run for soft-deleted
records.

Since Paranoia is no longer getting updated, we're forced to fork it
and add awareness of the new variable ourselves. The changes in this
commit are based on those in https://github.com/rubysherpas/paranoia/pull/404/files .

The main difference from that source is that since we know this private
fork is only getting used by us, I can drop the "are we on Rails 5.0
or earlier?" conditionals, though they should be added back if we ever
intend to submit this upstream.

Since I dropped those conditionals I changed the gemspec to require
ActiveRecord 5.1 or greater.