### PR TITLE
Update paranoia gem to 2.6.0 and re apply recursive callback fix

### DIFF
--- a/lib/paranoia.rb
+++ b/lib/paranoia.rb
@@ -104,12 +104,12 @@ module Paranoia
 
   def restore!(opts = {})
     self.class.transaction do
-      run_callbacks(:restore) do
-        recovery_window_range = get_recovery_window_range(opts)
-        # Fixes a bug where the build would error because attributes were frozen.
-        # This only happened on Rails versions earlier than 4.1.
-        noop_if_frozen = ActiveRecord.version < Gem::Version.new("4.1")
-        if within_recovery_window?(recovery_window_range) && ((noop_if_frozen && !@attributes.frozen?) || !noop_if_frozen)
+      recovery_window_range = get_recovery_window_range(opts)
+      # Fixes a bug where the build would error because attributes were frozen.
+      # This only happened on Rails versions earlier than 4.1.
+      noop_if_frozen = ActiveRecord.version < Gem::Version.new("4.1")
+      if within_recovery_window?(recovery_window_range) && ((noop_if_frozen && !@attributes.frozen?) || !noop_if_frozen)
+        run_callbacks(:restore) do
           @_disable_counter_cache = !paranoia_destroyed?
           write_attribute paranoia_column, paranoia_sentinel_value
           update_columns(paranoia_restore_attributes)
@@ -119,8 +119,9 @@ module Paranoia
             end
           end
           @_disable_counter_cache = false
+
+          restore_associated_records(recovery_window_range) if opts[:recursive]
         end
-        restore_associated_records(recovery_window_range) if opts[:recursive]
       end
     end
 

--- a/lib/paranoia/version.rb
+++ b/lib/paranoia/version.rb
@@ -1,3 +1,3 @@
 module Paranoia
-  VERSION = '2.6.0'.freeze
+  VERSION = '2.6.0.redguava.1'.freeze
 end


### PR DESCRIPTION
This [upstream update](https://github.com/rubysherpas/paranoia/blob/core/CHANGELOG.md) allowed removal of some of the custom fixes but the errors for running callbacks on associated records within the recovery window remains.

This fix has been re-applied.

The rest of the changes mainly relate to Rails 6.0 compatibility and upstreaming the fixes Hass made in our fork.